### PR TITLE
Schema for Custom Signatures, Improved File Formats Schema, and Dynamic Schema Tests

### DIFF
--- a/.github/workflows/check-json.yml
+++ b/.github/workflows/check-json.yml
@@ -28,12 +28,16 @@ jobs:
       - name: Check JSON Schemata
         run: |
           for schema in *.schema.json; do
-            [[ -f "${schema%.schema.json}.json" ]] && python3 -c 'import json,jsonschema,sys;jsonschema.validate(json.load(open(sys.argv[1])), json.load(open(sys.argv[2])))' "${schema%.schema.json}.json" "$schema";
+            if [[ -f "${schema%.schema.json}.json" ]]; then
+              python3 -c 'import json,jsonschema,sys;jsonschema.validate(json.load(open(sys.argv[1])), json.load(open(sys.argv[2])))' "${schema%.schema.json}.json" "$schema";
+            fi;
           done
       - name: Check YAML Schemata
         run: |
           for schema in *.schema.json; do
             for ext in "yaml" "yml"; do
-              [[ -f "${schema%.schema.json}.$ext" ]] && python3 -c 'import yaml,json,jsonschema,sys;jsonschema.validate(yaml.load(open(sys.argv[1]), yaml.Loader), json.load(open(sys.argv[2])))' "${schema%.schema.json}.$ext" "$schema";
+              if [[ -f "${schema%.schema.json}.$ext" ]]; then
+                python3 -c 'import yaml,json,jsonschema,sys;jsonschema.validate(yaml.load(open(sys.argv[1]), yaml.Loader), json.load(open(sys.argv[2])))' "${schema%.schema.json}.$ext" "$schema";
+              fi;
             done
           done

--- a/.github/workflows/check-json.yml
+++ b/.github/workflows/check-json.yml
@@ -25,5 +25,15 @@ jobs:
         uses: limitusus/json-syntax-check@v2
         with:
           pattern: "\\.json$"
-      - name: Check Actions Schema
-        run: python -c 'import yaml,json,jsonschema,sys;jsonschema.validate(yaml.load(open(sys.argv[1]), yaml.Loader), json.load(open(sys.argv[2])))' fileformats.yml fileformats.schema.json
+      - name: Check JSON Schemata
+        run: |
+          for schema in *.schema.json; do
+            [[ -f "${schema%.schema.json}.json" ]] && python3 -c 'import json,jsonschema,sys;jsonschema.validate(json.load(open(sys.argv[1])), json.load(open(sys.argv[2])))' "${schema%.schema.json}.json" "$schema";
+          done
+      - name: Check YAML Schemata
+        run: |
+          for schema in *.schema.json; do
+            for ext in "yaml" "yml"; do
+              [[ -f "${schema%.schema.json}.$ext" ]] && python3 -c 'import yaml,json,jsonschema,sys;jsonschema.validate(yaml.load(open(sys.argv[1]), yaml.Loader), json.load(open(sys.argv[2])))' "${schema%.schema.json}.$ext" "$schema";
+            done
+          done

--- a/custom_signatures.schema.json
+++ b/custom_signatures.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "actions",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "dependencies": {
+      "operator": [
+        "bof",
+        "eof"
+      ]
+    },
+    "if": {
+      "required": [
+        "bof",
+        "eof"
+      ]
+    },
+    "then": {
+      "required": [
+        "operator"
+      ]
+    },
+    "properties": {
+      "bof": {
+        "type": "string"
+      },
+      "eof": {
+        "type": "string"
+      },
+      "operator": {
+        "type": "string",
+        "enum": [
+          "AND",
+          "OR",
+          "XOR"
+        ]
+      },
+      "puid": {
+        "type": "string"
+      },
+      "signature": {
+        "type": "string"
+      },
+      "extension": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/fileformats.schema.json
+++ b/fileformats.schema.json
@@ -2,8 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "actions",
   "type": "object",
+  "additionalProperties": false,
   "patternProperties": {
-    ".*": {
+    ".+": {
       "type": "object",
       "required": [
         "name",

--- a/fileformats.schema.json
+++ b/fileformats.schema.json
@@ -9,6 +9,68 @@
         "name",
         "action"
       ],
+      "oneOf": [
+        {
+          "properties": {
+            "action": {
+              "const": "convert"
+            }
+          },
+          "required": [
+            "convert"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "extract"
+            }
+          },
+          "required": [
+            "extract"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "manual"
+            }
+          },
+          "required": [
+            "manual"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "rename"
+            }
+          },
+          "required": [
+            "rename"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "ignore"
+            }
+          },
+          "required": [
+            "ignore"
+          ]
+        },
+        {
+          "properties": {
+            "action": {
+              "const": "reidentify"
+            }
+          },
+          "required": [
+            "reidentify"
+          ]
+        }
+      ],
       "properties": {
         "name": {
           "type": "string"

--- a/fileformats.schema.json
+++ b/fileformats.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "additionalProperties": false,
   "patternProperties": {
-    ".+": {
+    "^[a-zA-Z0-9_/-]+$": {
       "type": "object",
       "required": [
         "name",


### PR DESCRIPTION
## Custom Signatures

* Added custom_signatures.schema.json to control structure of custom_signatures.json
* Ensures that `eof` and `bof` can either be set alone (XOR), or requires `operator` if they are both set

## File Formats

* Require that the property of an action be set if the `action` property is set to it (i.e., if `action: convert`, then the `convert` property is required)
* Require PUID keys to contain at least one character and can only contain letters, numbers, dashes, underscores, and slashes (`[a-zA-Z0-9_/-]`)

## Tests

* Schemata tests are now performed dynamically based on the name of schema files