### PR TITLE
Addition of wmz files. Files that changes app interface appearance

### DIFF
--- a/fileformats.yml
+++ b/fileformats.yml
@@ -2384,6 +2384,7 @@ x-fmt/263:
   alternatives:
     .xps: fmt/657
     .oxps: fmt/657
+    .kmz: fmt/724
   action: extract
   extract:
     tool: zip


### PR DESCRIPTION
This fileformat is used for changing the appearance of the interface for Windows Media Player. This file is compressed using GZIP, therefore looks for the GZIP header and the .wmz file extension. This file is not preservation-worthy.

Example of this file:
AVID.AARS.80.1_MTM-Arkiv-POB/OriginalDocuments/docCollection28/271216/image001.wmz