### PR TITLE
Identify kmz files as fmt/724 instead of as a zip file (fmt/263)

### DIFF
--- a/custom_signatures.yml
+++ b/custom_signatures.yml
@@ -148,7 +148,7 @@
   puid: aca-fmt/26
   signature: Lotus Notes Doclink File
   description: Link file used by Lotus Notes, a business productivity and collaboration application suite; saved in an XML format and contains a reference to a Lotus Notes document; used for sharing links to documents over email and in Web pages.
-- bof: (?i)1f8b08
+- bof: (?i)^1f8b08
   plain_bof: ""
   extension: .wmz
   puid: aca-fmt/27

--- a/custom_signatures.yml
+++ b/custom_signatures.yml
@@ -148,3 +148,9 @@
   puid: aca-fmt/26
   signature: Lotus Notes Doclink File
   description: Link file used by Lotus Notes, a business productivity and collaboration application suite; saved in an XML format and contains a reference to a Lotus Notes document; used for sharing links to documents over email and in Web pages.
+- bof: (?i)1f8b08
+  plain_bof: ""
+  extension: .wmz
+  puid: aca-fmt/27
+  signature: Windows Media Player Skin Package
+  description: A WMZ file is a pre-installed or custom skin that changes the appearance of the Windows Media Player interface, often to match a certain theme. It contains a combination of graphics and JScript code that defines the look and behavior of each skin element. WMZ files are compressed using ZIP compression.

--- a/fileformats.yml
+++ b/fileformats.yml
@@ -2408,6 +2408,7 @@ x-fmt/266:
   alternatives:
     .emz: aca-fmt/22
     .emz.gz: aca-fmt/22
+    .wmz: aca-fmt/27
 x-fmt/280:
   name: XML Schema Definition
   action: ignore

--- a/fileformats.yml
+++ b/fileformats.yml
@@ -121,6 +121,12 @@ aca-fmt/26:
   ignore:
     template: not-preservable
     reason: Used for sharing links to documents over email and in Web pages. Not preservation-worthy
+aca-fmt/27:
+  name: Windows Media Player Skin Package
+  action: ignore
+  ignore:
+    template: not-preservable
+    reason: Pre-installed or custom skin that changes the appearance of the Windows Media Player interface. Not preservation-worthy
 fmt/3:
   name: Graphics Interchange Format 87a
   ignore_if:

--- a/fileformats.yml
+++ b/fileformats.yml
@@ -2383,6 +2383,7 @@ x-fmt/263:
   alternatives:
     .xps: fmt/657
     .oxps: fmt/657
+    .kmz: fmt/724
   action: extract
   extract:
     tool: zip


### PR DESCRIPTION
digiarch misidentifies kmz files strictly as a zip file, however, digiarch should identify this file-extension as the already specified puid for .kmz files (fmt/724). Adding the puid for .kmz files as an alternative under the puid of zip files should fix this problem.

For example, the following file is currently identifies as fmt/263:

AVID.AARS.80.1_MTM-Arkiv-POB/OriginalDocuments/docCollection20/196006/udstykningsplantilgoogleearth.kmz

Even though it clearly is fmt/724,