### PR TITLE
x-fmt/414

### DIFF
--- a/fileformats.yml
+++ b/fileformats.yml
@@ -2588,6 +2588,12 @@ x-fmt/413:
   ignore:
     template: not-preservable
     reason: An executable non-binary .bat-file. Not preservation-worthy
+x-fmt/414:
+  name: Windows Cabinet File
+  action: ignore
+  ignore:
+    template: not-preservable
+    reason: CAB files contain Windows system or device driver updates. Not preservation-worthy
 x-fmt/415:
   name: Java Compiled Object Code
   action: ignore


### PR DESCRIPTION
Windows Cabinet File (CAB) indeholder information omkring Windows eller opdateringer. Dette er ikke bevaringsværdigt. På nettet så virker det umiddelbart, som det eneste man bruger CAD filer til.

Dog, en bruger kan faktisk godt lave deres egen CAD file (den virker lidt som en zip file). Så jeg er faktisk lidt i tvivl om det er en for grov sortering, hvis CAD sættes til ikke-bevaringsværdigt.
