### PR TITLE
Chunk Size for Reidentify

### DIFF
--- a/fileformats.schema.json
+++ b/fileformats.schema.json
@@ -421,6 +421,12 @@
               "description": "The reason why the file should be re-identified.",
               "type": "string"
             },
+            "chunk_size": {
+              "description": "Specify how many bytes should be used to search for the custom signature, defaults to 1024.",
+              "default": 1024,
+              "type": "integer",
+              "minimum": 1
+            },
             "on_fail": {
               "description": "The action to take if no new signature can be found.",
               "type": "string",

--- a/fileformats.yml
+++ b/fileformats.yml
@@ -2469,10 +2469,11 @@ x-fmt/346:
   action: ignore
   reidentify:
     reason: Pronom identifies the format on extension alone
+    chunk_size: 2048
     on_fail: "action"
   ignore:
     template: not-convertable
-    reason: At the moment the file can't be convertet with the current tools for CAD-files.
+    reason: At the moment the file can't be converted with the current tools for CAD-files.
 x-fmt/375:
   name: CorelDraw Drawing
   action: convert


### PR DESCRIPTION
## Changes

* Add `reidentify.chunk_size` field to specify how many bytes should be used to search for custom signatures