### PR TITLE
Master actions - add x-fmt/111

### DIFF
--- a/fileformats_master.yml
+++ b/fileformats_master.yml
@@ -112,6 +112,14 @@ fmt/353:
     tool: image
     output: tif
 
+x-fmt/111:
+  access:
+    tool: copy
+  statutory:
+    tool: text
+    output: tif
+
+
 # Custom puids
 aca-fmt/29:
   # should just be copied to statutory along the .gml file


### PR DESCRIPTION
Plain text files do not have a file class in the PRONOM system, so the PUID needs to be added explicitly.